### PR TITLE
Listed DCMTK authors (OFFIS, OC, J. Riesmeier).

### DIFF
--- a/_posts/2018-01-29-DCMTK.md
+++ b/_posts/2018-01-29-DCMTK.md
@@ -13,7 +13,7 @@ categories:
 
 [_DCMTK_](http://dcmtk.org/dcmtk.php.en) is a collection of libraries and applications implementing large parts the DICOM standard. It includes software for examining, constructing and converting DICOM image files, handling offline media, sending and receiving images over a network connection, as well as demonstrative image storage and worklist servers. DCMTK is is written in a mixture of ANSI C and C++. It comes in complete source code and is made available as "open source" software.
 
-DCMTK is developed and maintained by the [Oldenburger OFFIS - Institut für Informatik (OFFIS - Institute for Information Technology)](https://www.offis.de/en.html) located in Oldenburg, Germany.
+DCMTK is developed and maintained by a team located in Oldenburg, Germany, consisting of [OFFIS e.V.](https://www.offis.de/en.html), [Open Connections GmbH](https://www.open-connections.de) and [J. Riesmeier](https://www.jriesmeier.de).
 
 QIICR supported implementation of the new functionality into DCMTK, specifically, development of the following components:
 * [dcmiod](http://support.dcmtk.org/docs/mod_dcmiod.html): a library for working with information objects and modules

--- a/_posts/2018-01-29-DCMTK.md
+++ b/_posts/2018-01-29-DCMTK.md
@@ -13,7 +13,7 @@ categories:
 
 [_DCMTK_](http://dcmtk.org/dcmtk.php.en) is a collection of libraries and applications implementing large parts the DICOM standard. It includes software for examining, constructing and converting DICOM image files, handling offline media, sending and receiving images over a network connection, as well as demonstrative image storage and worklist servers. DCMTK is is written in a mixture of ANSI C and C++. It comes in complete source code and is made available as "open source" software.
 
-DCMTK is developed and maintained by a team located in Oldenburg, Germany, consisting of [OFFIS e.V.](https://www.offis.de/en.html), [Open Connections GmbH](https://www.open-connections.de) and [J. Riesmeier](https://www.jriesmeier.de).
+DCMTK is developed and maintained by a team located in Oldenburg, Germany, consisting of [OFFIS e.V.](https://www.offis.de/en.html), [Open Connections GmbH](https://www.open-connections.de) and [J. Riesmeier](https://www.jriesmeier.com).
 
 QIICR supported implementation of the new functionality into DCMTK, specifically, development of the following components:
 * [dcmiod](http://support.dcmtk.org/docs/mod_dcmiod.html): a library for working with information objects and modules


### PR DESCRIPTION
Made clear that DCMTK is not only developed by OFFIS (specifically in
this project). Shortened link descriptions.